### PR TITLE
"Brooklyn JS 24 talk proposal"

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,8 +267,8 @@
             To add yourself to this slot, change the following two lines
             and add a short description paragraph in the pull request.
           -->
-          <small>Seeking documentation UI nirvana, with</small>
-          <div><a href="https://github.com/brooklynjs/brooklynjs.github.io/edit/master/index.html">ERIC WILLIAM LIN</a></div>
+          <small>Listen to our second speaker, or better yet</small>
+          <div><a href="https://github.com/brooklynjs/brooklynjs.github.io/edit/master/index.html">BE OUR SECOND SPEAKER</a></div>
         </li>
         <li class="ride"></li>
         <li class="speaker">


### PR DESCRIPTION
Reverts ewlin/brooklynjs.github.io#1
